### PR TITLE
Including ancestor title (if exists) in jest test results.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ vstest.console.exe --Isolation --TestAdapterPath:<path> <files> -- JSTest.DebugL
 
 #### Using RunSettings xml defined for vstest:
 ```bash
-vstest.console.exe --Isolation --Settings:RunSettings.xml --TestAdapterPath:<path> <files>
+vstest.console.exe --Settings:RunSettings.xml --TestAdapterPath:<path> <files>
 ```
 With RunSettings.xml:
 ```xml

--- a/src/JSTest.Runner/TestRunner/TestFrameworks/Jest/JestReporter.ts
+++ b/src/JSTest.Runner/TestRunner/TestFrameworks/Jest/JestReporter.ts
@@ -60,12 +60,18 @@ class JestReporter {
             if (result.pending === true) {
                 outcome = TestOutcome.Skipped;
             }
-            
+
+            // Jest provides test suite title as ancestor titles. Use them if provided
+            let resultTitle = result.title;
+            if (result.ancestorTitles && result.ancestorTitles.length > 0) {
+                resultTitle = [...result.ancestorTitles, resultTitle].join(" > ");
+            }
+        
             if (JestReporter.discovery) {
-                JestReporter.callbacks.handleSpecFound(result.fullName, result.title, test.path);
+                JestReporter.callbacks.handleSpecFound(result.fullName, resultTitle, test.path);
             } else {
                 JestReporter.callbacks.handleSpecResult(result.fullName,
-                                                        result.title,
+                                                        resultTitle,
                                                         test.path,
                                                         outcome,
                                                         failedExpectations,

--- a/test/JSTest.AcceptanceTests/BaseFrameworkTest.cs
+++ b/test/JSTest.AcceptanceTests/BaseFrameworkTest.cs
@@ -244,7 +244,12 @@ namespace JSTest.AcceptanceTests
             };
 
             var output = this.RunTests(files, cliOptions, runConfig);
-            var expectedStdOut = new List<string> { "Passed   test case a1", "Failed   test case a2", "Passed   test case b1", "Failed   test case a2" };
+            var expectedStdOut = new List<string> {
+                "Passed   suite a > test case a1",
+                "Failed   suite a > test case a2",
+                "Passed   suite b > test case b1",
+                "Failed   suite b > test case b2"
+            };
 
             this.ValidateOutput(output, expectedStdOut, false);
         }

--- a/test/JSTest.AcceptanceTests/BaseFrameworkTest.cs
+++ b/test/JSTest.AcceptanceTests/BaseFrameworkTest.cs
@@ -233,7 +233,7 @@ namespace JSTest.AcceptanceTests
             this.ValidateOutput(output, expectedOutput);
         }
 
-        protected virtual List<string> GetExpectedOutput()
+        protected virtual List<string> GetExpectedTestOutput()
         {
             return new List<string>
             {
@@ -255,7 +255,7 @@ namespace JSTest.AcceptanceTests
             };
 
             var output = this.RunTests(files, cliOptions, runConfig);
-            var expectedStdOut = this.GetExpectedOutput();
+            var expectedStdOut = this.GetExpectedTestOutput();
 
             this.ValidateOutput(output, expectedStdOut, false);
         }

--- a/test/JSTest.AcceptanceTests/BaseFrameworkTest.cs
+++ b/test/JSTest.AcceptanceTests/BaseFrameworkTest.cs
@@ -38,7 +38,7 @@ namespace JSTest.AcceptanceTests
 
         public BaseFrameworkTest()
         {
-           }
+        }
 
         #endregion
 
@@ -48,7 +48,7 @@ namespace JSTest.AcceptanceTests
         {
             var process = new Process();
             var startInfo = new ProcessStartInfo();
-            
+
             startInfo.UseShellExecute = false;
             startInfo.WindowStyle = ProcessWindowStyle.Normal;
             startInfo.FileName = BaseFrameworkTest.vstestPath;
@@ -60,7 +60,7 @@ namespace JSTest.AcceptanceTests
             process.StartInfo.UseShellExecute = false;
 
             Console.Write($"{startInfo.FileName} {startInfo.Arguments}");
-            
+
             return new ExecutionOutput(process);
         }
 
@@ -73,7 +73,7 @@ namespace JSTest.AcceptanceTests
             startInfo.WindowStyle = ProcessWindowStyle.Hidden;
             startInfo.FileName = "cmd.exe";
             startInfo.WorkingDirectory = BaseFrameworkTest.testRepoPath;
-            startInfo.Arguments = $"/C npm install {package}{ (packageVersion != "" ? $"@{packageVersion}" :  "") } --silent";
+            startInfo.Arguments = $"/C npm install {package}{ (packageVersion != "" ? $"@{packageVersion}" : "") } --silent";
             startInfo.RedirectStandardError = true;
             startInfo.RedirectStandardOutput = true;
 
@@ -130,9 +130,9 @@ namespace JSTest.AcceptanceTests
         {
             var args = $"--Inisolation --TestAdapterPath:{Path.Combine(BaseFrameworkTest.testRepoPath, "node_modules", "jstestadapter")}";
 
-            foreach(var entry in cliOptions)
+            foreach (var entry in cliOptions)
             {
-                args += " --" + entry.Key + (!string.IsNullOrEmpty(entry.Value)? ":" + entry.Value: string.Empty);
+                args += " --" + entry.Key + (!string.IsNullOrEmpty(entry.Value) ? ":" + entry.Value : string.Empty);
             }
 
             foreach (var file in files)
@@ -183,7 +183,7 @@ namespace JSTest.AcceptanceTests
 
             var jstestPackageFolder = Path.Combine(projectFolder, "artifacts", config);
 
-            var packageVersion= JObject.Parse(File.ReadAllText(Path.Combine(projectFolder, "package.json")))["version"];
+            var packageVersion = JObject.Parse(File.ReadAllText(Path.Combine(projectFolder, "package.json")))["version"];
             var package = Directory.EnumerateFiles(jstestPackageFolder, $"jstestadapter-{packageVersion}.tgz", SearchOption.TopDirectoryOnly);
 
             BaseFrameworkTest.jstestPackage = package.First();
@@ -233,6 +233,17 @@ namespace JSTest.AcceptanceTests
             this.ValidateOutput(output, expectedOutput);
         }
 
+        protected virtual List<string> GetExpectedOutput()
+        {
+            return new List<string>
+            {
+                "Passed   test case a1",
+                "Failed   test case a2",
+                "Passed   test case b1",
+                "Failed   test case b2"
+            };
+        }
+
         public void TestExecution()
         {
             var files = Directory.EnumerateFiles(BaseFrameworkTest.testRepoPath).Where((file) => file.EndsWith(this.ContainerExtension));
@@ -244,12 +255,7 @@ namespace JSTest.AcceptanceTests
             };
 
             var output = this.RunTests(files, cliOptions, runConfig);
-            var expectedStdOut = new List<string> {
-                "Passed   suite a > test case a1",
-                "Failed   suite a > test case a2",
-                "Passed   suite b > test case b1",
-                "Failed   suite b > test case b2"
-            };
+            var expectedStdOut = this.GetExpectedOutput();
 
             this.ValidateOutput(output, expectedStdOut, false);
         }
@@ -260,7 +266,7 @@ namespace JSTest.AcceptanceTests
 
         private void ValidateOutput(ExecutionOutput output, IEnumerable<string> expectedStdOut, bool failOnStdErr = true)
         {
-            if(output.ProcessTimeout)
+            if (output.ProcessTimeout)
             {
                 Assert.Fail("Process timed out");
             }
@@ -297,4 +303,3 @@ namespace JSTest.AcceptanceTests
         #endregion
     }
 }
- 

--- a/test/JSTest.AcceptanceTests/JestFramework.cs
+++ b/test/JSTest.AcceptanceTests/JestFramework.cs
@@ -43,5 +43,16 @@ namespace JSTest.AcceptanceTests
         {
             this.TestDiscovery();
         }
+
+        protected virtual List<string> GetExpectedOutput()
+        {
+            return new List<string>
+            {
+                "Passed   suite a > test case a1",
+                "Failed   suite a > test case a2",
+                "Passed   suite b > test case b1",
+                "Failed   suite b > test case b2"
+            };
+        }
     }
 }

--- a/test/JSTest.AcceptanceTests/JestFramework.cs
+++ b/test/JSTest.AcceptanceTests/JestFramework.cs
@@ -44,7 +44,7 @@ namespace JSTest.AcceptanceTests
             this.TestDiscovery();
         }
 
-        protected virtual List<string> GetExpectedOutput()
+        protected override List<string> GetExpectedTestOutput()
         {
             return new List<string>
             {


### PR DESCRIPTION
Here is a sample test:

 ```
describe("abc", () => {
    describe("xyz", () => {
        it("test 1", () => { expect(2 + 2).toBe(4); });

        describe("123", () => {
            it("test 2", () => { expect(2 + 2).toBe(4); });
        });

        it("test 3", () => { expect(2 + 2).toBe(4); });
    });

    it("test 4", () => { expect(2 + 2).toBe(4); });
});

it("test 5", () => { expect(2 + 2).toBe(4); });
it("test 6", () => { expect(2 + 2).toBe(4); });

describe("qwe", () => {
    it("test 7", () => { expect(2 + 2).toBe(4); });
});
```

Results before this change:
![image](https://user-images.githubusercontent.com/1160381/48252981-32d21200-e3d4-11e8-9d95-f88ae1a0b130.png)

After:
![image](https://user-images.githubusercontent.com/1160381/48253045-572dee80-e3d4-11e8-9def-d0bb70872b42.png)

