### PR TITLE
adding rootFolder flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ TestFramework           | One of the following test frameworks for execution: Ja
 DebugLogs               | Enable debug logs for JavaScript test runner                                          | false
 DebugFilePath           | Path for diagnostic logs                                                              | ""
 TestFrameworkConfigJson | Override test framework configurations (Specific to the testframework) in json format | {}
-RootFolder              | Override location of root directory where the node_modules folder would be            | ""
+NodeModulesPath         | Override path to node_modules                                                         | ""
 
 #### RunSettings can be provided through the the vstest cli itself:
 ```bash

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ TestFramework           | One of the following test frameworks for execution: Ja
 DebugLogs               | Enable debug logs for JavaScript test runner                                          | false
 DebugFilePath           | Path for diagnostic logs                                                              | ""
 TestFrameworkConfigJson | Override test framework configurations (Specific to the testframework) in json format | {}
-NodeModulesPath         | Override path to node_modules                                                         | ""
+NodeModulesPath         | Custom path to node_modules                                                         | ""
 
 #### RunSettings can be provided through the the vstest cli itself:
 ```bash

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ Option                  |  Usage                                                
 TestFramework           | One of the following test frameworks for execution: Jasmine/Mocha/Jest                | Jasmine
 DebugLogs               | Enable debug logs for JavaScript test runner                                          | false
 DebugFilePath           | Path for diagnostic logs                                                              | ""
-TestFrameworkConfigJson | Override test framework configurations (Specific to the testframework) in json format | {} 
+TestFrameworkConfigJson | Override test framework configurations (Specific to the testframework) in json format | {}
+RootFolder              | Override location of root directory where the node_modules folder would be            | ""
 
 #### RunSettings can be provided through the the vstest cli itself:
 ```bash

--- a/src/JSTest/Interfaces/IRuntimeProvider.cs
+++ b/src/JSTest/Interfaces/IRuntimeProvider.cs
@@ -5,6 +5,6 @@
 
     internal interface IRuntimeProvider
     {
-        TestProcessStartInfo GetRuntimeProcessInfo(string nodePath, string rootPath, bool debugEnabled, IEnumerable<string> sources);
+        TestProcessStartInfo GetRuntimeProcessInfo(string nodePath, string nodeModulesPath, bool debugEnabled, IEnumerable<string> sources);
     }
 }

--- a/src/JSTest/Interfaces/IRuntimeProvider.cs
+++ b/src/JSTest/Interfaces/IRuntimeProvider.cs
@@ -5,6 +5,6 @@
 
     internal interface IRuntimeProvider
     {
-        TestProcessStartInfo GetRuntimeProcessInfo(string nodePath, bool debugEnabled, IEnumerable<string> sources);
+        TestProcessStartInfo GetRuntimeProcessInfo(string nodePath, string rootPath, bool debugEnabled, IEnumerable<string> sources);
     }
 }

--- a/src/JSTest/RuntimeProviders/NodeRuntimeProvider.cs
+++ b/src/JSTest/RuntimeProviders/NodeRuntimeProvider.cs
@@ -13,9 +13,10 @@
     {
         public static NodeRuntimeProvider Instance { get; } = new NodeRuntimeProvider();
 
-        public TestProcessStartInfo GetRuntimeProcessInfo(string nodePath, string rootFolder, bool isDebugEnabled, IEnumerable<string> sources)
+        public TestProcessStartInfo GetRuntimeProcessInfo(string nodePath, string nodeModulesPath, bool isDebugEnabled, IEnumerable<string> sources)
         {
             var processInfo = new TestProcessStartInfo();
+            string rootFolder = Path.GetDirectoryName(typeof(TestRunner).GetTypeInfo().Assembly.GetAssemblyLocation());
 
             if (!string.IsNullOrWhiteSpace(nodePath))
             {
@@ -36,16 +37,10 @@
                 processInfo.FileName = "node.exe";
             }
 
-            if (string.IsNullOrWhiteSpace(rootFolder))
-            {
-                rootFolder = Path.GetDirectoryName(typeof(TestRunner).GetTypeInfo().Assembly.GetAssemblyLocation());
-            }
-
-
             var jstestrunner = Path.Combine(rootFolder, "index.js");
             processInfo.EnvironmentVariables = new Dictionary<string, string>
             {
-                { "NODE_PATH", InitNodePath(sources, rootFolder) },
+                { "NODE_PATH",  string.IsNullOrEmpty(nodeModulesPath) ? InitNodePath(sources, rootFolder) : nodeModulesPath },
                 { "NODE_NO_WARNINGS", "1" }
             };
 

--- a/src/JSTest/RuntimeProviders/NodeRuntimeProvider.cs
+++ b/src/JSTest/RuntimeProviders/NodeRuntimeProvider.cs
@@ -13,10 +13,10 @@
     {
         public static NodeRuntimeProvider Instance { get; } = new NodeRuntimeProvider();
 
-        public TestProcessStartInfo GetRuntimeProcessInfo(string nodePath, bool isDebugEnabled, IEnumerable<string> sources)
+        public TestProcessStartInfo GetRuntimeProcessInfo(string nodePath, string rootFolder, bool isDebugEnabled, IEnumerable<string> sources)
         {
             var processInfo = new TestProcessStartInfo();
-            string rootFolder = Path.GetDirectoryName(typeof(TestRunner).GetTypeInfo().Assembly.GetAssemblyLocation());
+
             if (!string.IsNullOrWhiteSpace(nodePath))
             {
                 processInfo.FileName = nodePath;
@@ -35,6 +35,12 @@
             {
                 processInfo.FileName = "node.exe";
             }
+
+            if (string.IsNullOrWhiteSpace(rootFolder))
+            {
+                rootFolder = Path.GetDirectoryName(typeof(TestRunner).GetTypeInfo().Assembly.GetAssemblyLocation());
+            }
+
 
             var jstestrunner = Path.Combine(rootFolder, "index.js");
             processInfo.EnvironmentVariables = new Dictionary<string, string>

--- a/src/JSTest/RuntimeProviders/NodeRuntimeProvider.cs
+++ b/src/JSTest/RuntimeProviders/NodeRuntimeProvider.cs
@@ -40,7 +40,7 @@
             var jstestrunner = Path.Combine(rootFolder, "index.js");
             processInfo.EnvironmentVariables = new Dictionary<string, string>
             {
-                { "NODE_PATH",  string.IsNullOrEmpty(nodeModulesPath) ? InitNodePath(sources, rootFolder) : nodeModulesPath },
+                { "NODE_PATH",  InitNodePath(sources, rootFolder, nodeModulesPath) },
                 { "NODE_NO_WARNINGS", "1" }
             };
 
@@ -50,7 +50,7 @@
             return processInfo;
         }
 
-        private string InitNodePath(IEnumerable<string> sources, string root)
+        private string InitNodePath(IEnumerable<string> sources, string root, string nodeModulesPath)
         {
             var node_path = Environment.GetEnvironmentVariable("NODE_PATH");
             if (!string.IsNullOrEmpty(node_path))
@@ -75,6 +75,11 @@
                     paths.Add(path);
                     path = Path.GetDirectoryName(path);
                 }
+            }
+
+            if (!string.IsNullOrEmpty(nodeModulesPath))
+            {
+                node_path += ";" + nodeModulesPath;
             }
 
             return node_path;

--- a/src/JSTest/RuntimeProviders/RuntimeProviderFactory.cs
+++ b/src/JSTest/RuntimeProviders/RuntimeProviderFactory.cs
@@ -29,7 +29,7 @@ namespace JSTest.RuntimeProviders
             switch (settings.Runtime)
             {
                 case JavaScriptRuntime.NodeJS:
-                    return NodeRuntimeProvider.Instance.GetRuntimeProcessInfo(settings.NodePath, this.IsRuntimeDebuggingEnabled, sources);
+                    return NodeRuntimeProvider.Instance.GetRuntimeProcessInfo(settings.NodePath, settings.RootFolder, this.IsRuntimeDebuggingEnabled, sources);
             }
 
             return null;

--- a/src/JSTest/RuntimeProviders/RuntimeProviderFactory.cs
+++ b/src/JSTest/RuntimeProviders/RuntimeProviderFactory.cs
@@ -29,7 +29,7 @@ namespace JSTest.RuntimeProviders
             switch (settings.Runtime)
             {
                 case JavaScriptRuntime.NodeJS:
-                    return NodeRuntimeProvider.Instance.GetRuntimeProcessInfo(settings.NodePath, settings.RootFolder, this.IsRuntimeDebuggingEnabled, sources);
+                    return NodeRuntimeProvider.Instance.GetRuntimeProcessInfo(settings.NodePath, settings.NodeModulesPath, this.IsRuntimeDebuggingEnabled, sources);
             }
 
             return null;

--- a/src/JSTest/Settings/JSTestSettings.cs
+++ b/src/JSTest/Settings/JSTestSettings.cs
@@ -82,6 +82,9 @@ namespace JSTest.Settings
         [XmlElement("NodePath")]
         public string NodePath { get; set; }
 
+        [XmlElement("RootFolder")]
+        public string RootFolder { get; set; }
+
         [DataMember]
         public string TestFrameworkConfigJson { get; set; }
 
@@ -97,6 +100,7 @@ namespace JSTest.Settings
             this.RunInParallel = true;
             this.DebugLogs = false;
             this.NodePath = string.Empty;
+            this.RootFolder = string.Empty;
             this.DebugFilePath = string.Empty;
             this.AttachmentsFolder = string.Empty;
         }

--- a/src/JSTest/Settings/JSTestSettings.cs
+++ b/src/JSTest/Settings/JSTestSettings.cs
@@ -82,8 +82,8 @@ namespace JSTest.Settings
         [XmlElement("NodePath")]
         public string NodePath { get; set; }
 
-        [XmlElement("RootFolder")]
-        public string RootFolder { get; set; }
+        [XmlElement("NodeModulesPath")]
+        public string NodeModulesPath { get; set; }
 
         [DataMember]
         public string TestFrameworkConfigJson { get; set; }
@@ -100,7 +100,7 @@ namespace JSTest.Settings
             this.RunInParallel = true;
             this.DebugLogs = false;
             this.NodePath = string.Empty;
-            this.RootFolder = string.Empty;
+            this.NodeModulesPath = string.Empty;
             this.DebugFilePath = string.Empty;
             this.AttachmentsFolder = string.Empty;
         }

--- a/test/JSTest.UnitTests/RuntimeProviders/NodeRuntimeProviderTests.cs
+++ b/test/JSTest.UnitTests/RuntimeProviders/NodeRuntimeProviderTests.cs
@@ -22,7 +22,7 @@
         public void GetRuntimeProcessInfoWillReturnProcessInfoWithCorrectProperties()
         {
             var sources = new string[] { "source1", "source2", "source3" };
-            var startInfo = this.runtimeProvider.GetRuntimeProcessInfo(null, false, sources);
+            var startInfo = this.runtimeProvider.GetRuntimeProcessInfo(null, null, false, sources);
             var arguments = Regex.Match(startInfo.Arguments, " -r source-map-support/register (.*)");
 
             Assert.IsTrue(arguments.Groups[1].Value.EndsWith("index.js"));


### PR DESCRIPTION
adding rootFolder as a setting that can  be applied. 

I tried just setting NODE_PATH as an environment variable but there were collisions when adding it as an environment  variable when I started up the JSTestAdapter. I was thinking perhaps we can apply it as a setting in the JSTest config?