### PR TITLE
add RunInDomain option to JSTestSettings

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,13 @@
 jstestadapter is a JavaScript test adapter extension for [Visual Studio Test Platform](https://github.com/Microsoft/vstest). jstest with vstest can be used as a command line tool to run tests written in mocha, jasmine or jest.
 
 ### Install
+
 ```bash
 npm install --save-dev jstestadapter
 ```
 
 ### Usage
+
 ```bash
 # Testing with default test framework, Jasmine
 path/to/vstest.console.exe --TestAdapterPath:./node_modules/jstestadapter/ path/to/test.1.js path/to/test.2.js
@@ -28,21 +30,26 @@ path/to/vstest.console.exe --TestAdapterPath:./node_modules/jstestadapter/ path/
 Option                  |  Usage                                                                                | Default
 ----------------------- | ------------------------------------------------------------------------------------- | --------
 TestFramework           | One of the following test frameworks for execution: Jasmine/Mocha/Jest                | Jasmine
+RunInDomain             | Run JavaScript tests in a node [Domain](https://nodejs.org/api/domain.html)           | true
 DebugLogs               | Enable debug logs for JavaScript test runner                                          | false
 DebugFilePath           | Path for diagnostic logs                                                              | ""
 TestFrameworkConfigJson | Override test framework configurations (Specific to the testframework) in json format | {}
-NodeModulesPath         | Custom path to node_modules                                                         | ""
+NodeModulesPath         | Custom path to node_modules                                                           | ""
 
-#### RunSettings can be provided through the the vstest cli itself:
+#### RunSettings can be provided through the the vstest cli itself
+
 ```bash
 vstest.console.exe --Isolation --TestAdapterPath:<path> <files> -- JSTest.DebugLogs=true JSTest.TestFramework=mocha
 ```
 
-#### Using RunSettings xml defined for vstest:
+#### Using RunSettings xml defined for vstest
+
 ```bash
 vstest.console.exe --Settings:RunSettings.xml --TestAdapterPath:<path> <files>
 ```
+
 With RunSettings.xml:
+
 ```xml
 <RunSettings>
     <JSTest>
@@ -61,6 +68,7 @@ With RunSettings.xml:
 For uploading test result attachments along with tests checkout [karanjitsingh/jstestcontext](https://github.com/karanjitsingh/jstestcontext)
 
 ### Building from source
+
 ```bash
 # Build binaries and javascript to `./artifacts/Debug/net451/` along with the package tarball in `./artifacts/Debug`
 .\scripts\build.ps1
@@ -94,9 +102,7 @@ For uploading test result attachments along with tests checkout [karanjitsingh/j
 | -test          | "test filter"                      | Test filter                             | -       |
 | -vstest        | \path\to\custom\vstest.console.exe | Path to vstest.console.exe              | D:\vstest\artifacts\Debug\net451\win7-x64\vstest.console.exe  |
 
-
 ---
-
 
 ##### Tested with framework versions
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ path/to/vstest.console.exe --TestAdapterPath:./node_modules/jstestadapter/ path/
 Option                  |  Usage                                                                                | Default
 ----------------------- | ------------------------------------------------------------------------------------- | --------
 TestFramework           | One of the following test frameworks for execution: Jasmine/Mocha/Jest                | Jasmine
-RunInDomain             | Run JavaScript tests in a node [Domain](https://nodejs.org/api/domain.html)           | true
+RunInDomain             | Run JavaScript tests in a node [Domain](https://nodejs.org/api/domain.html). _Note: If set to false the test must complete all execution before returning control. i.e. all callbacks such as setTimeout must be completed before the test completes execution._ | true
 DebugLogs               | Enable debug logs for JavaScript test runner                                          | false
 DebugFilePath           | Path for diagnostic logs                                                              | ""
 TestFrameworkConfigJson | Override test framework configurations (Specific to the testframework) in json format | {}

--- a/src/JSTest.Runner/ArgProcessor.ts
+++ b/src/JSTest.Runner/ArgProcessor.ts
@@ -12,8 +12,9 @@ import { CLIArgs } from './TestRunner/CLIArgs';
          for (let i = 4; i < env.argv.length; i++) {
             if (env.argv[i].startsWith('--')) {
                 switch (env.argv[i].substr(2).toLowerCase()) {
-                    case 'runInDomain':
+                    case 'runindomain':
                         runInDomain = true;
+                        break;
                     case 'diag':
                         debugEnabled = true;
                         if (env.argv[++i]) {

--- a/src/JSTest.Runner/ArgProcessor.ts
+++ b/src/JSTest.Runner/ArgProcessor.ts
@@ -5,12 +5,15 @@ import { CLIArgs } from './TestRunner/CLIArgs';
 
      export function processCLIArgs(env: IEnvironment): CLIArgs {
 
+        let runInDomain = false;
         let debugEnabled = false;
         let debugFilePath = '';
 
          for (let i = 4; i < env.argv.length; i++) {
             if (env.argv[i].startsWith('--')) {
                 switch (env.argv[i].substr(2).toLowerCase()) {
+                    case 'runInDomain':
+                        runInDomain = true;
                     case 'diag':
                         debugEnabled = true;
                         if (env.argv[++i]) {
@@ -29,7 +32,8 @@ import { CLIArgs } from './TestRunner/CLIArgs';
             ip: env.argv[2],
             port: Number(env.argv[3]),
             traceEnabled: debugEnabled,
-            traceFilePath: debugFilePath
+            traceFilePath: debugFilePath,
+            runInDomain: runInDomain
         };
     }
 } 

--- a/src/JSTest.Runner/ObjectModel/JSTestSettings.ts
+++ b/src/JSTest.Runner/ObjectModel/JSTestSettings.ts
@@ -10,6 +10,7 @@ export class JSTestSettings {
     public readonly TestFrameworkConfigJson: JSON;
     public readonly AttachmentsFolder: string;
     public readonly CoverageEnabled: boolean;
+    public readonly RunInDomain: boolean;
 
     constructor(json: any, environment: IEnvironment) {
         this.JavaScriptTestFramework = -1;
@@ -37,6 +38,7 @@ export class JSTestSettings {
         }
 
         this.CoverageEnabled = json.CodeCoverageEnabled === true;
+        this.RunInDomain = json.RunInDomain === true;
 
         // Set attachments folder and environment variable
         // TODO: we should probably get the env key from jstestcontext package

--- a/src/JSTest.Runner/TestRunner/CLIArgs.ts
+++ b/src/JSTest.Runner/TestRunner/CLIArgs.ts
@@ -3,4 +3,5 @@ export interface CLIArgs {
     port: number;
     traceEnabled: boolean;
     traceFilePath: string;
+    runInDomain: boolean;
 }

--- a/src/JSTest.Runner/TestRunner/ExecutionManagers/TestSessionManager.ts
+++ b/src/JSTest.Runner/TestRunner/ExecutionManagers/TestSessionManager.ts
@@ -17,22 +17,24 @@ export class TestSessionManager {
     private testSessionIterator: IterableIterator<TestSession>;
     private sessionCompleteCount: number;
     private sessionCount: number;
+    private runInDomain: boolean;
     public onAllSessionsComplete: IEvent<IEventArgs>;
 
     public static instance: TestSessionManager;
 
-    protected constructor(environment: IEnvironment) {
+    protected constructor(environment: IEnvironment, runInDomain: boolean) {
         this.sessionCount = 0;
         this.sessionCompleteCount = 0;
         this.onAllSessionsComplete = environment.createEvent();
         this.testSessionBucket = new Map();
         this.testSessionIterator = this.testSessionBucket.values();
+        this.runInDomain = runInDomain;
     }
 
-    public static INITIALIZE(environment: IEnvironment) {
+    public static INITIALIZE(environment: IEnvironment, runInDomain: boolean) {
         if (!TestSessionManager.instance) {
             EqtTrace.info(`TestSessionManager: initializing`);
-            TestSessionManager.instance = new TestSessionManager(environment);
+            TestSessionManager.instance = new TestSessionManager(environment, runInDomain);
         }
     }
 
@@ -75,7 +77,11 @@ export class TestSessionManager {
     }
 
     public executeJobs() {
-        this.runSessionInDomain(this.testSessionIterator.next().value);
+        if (this.runInDomain) {
+            this.runSessionInDomain(this.testSessionIterator.next().value);
+        } else {
+            this.runSession(this.testSessionIterator.next().value);
+        }
     }
 
     public updateSessionEventArgs(args: TestSessionEventArgs) {
@@ -86,6 +92,16 @@ export class TestSessionManager {
     public getSessionEventArgs(sources: Array<string>): TestSessionEventArgs {
         const sessionId = SessionHash(sources);
         return this.testSessionBucket.get(sessionId).TestSessionEventArgs;
+    }
+
+    protected runSession(testSession: TestSession) {
+        try {
+            EqtTrace.info(`TestSessionManager: Executing session with no domain`);
+            testSession.Job();
+        } catch (err) {
+            EqtTrace.error('TestSessionManager: error running session outside of domain', err);
+            this.sessionError(testSession, err);
+        }
     }
 
     protected runSessionInDomain(testSession: TestSession) {

--- a/src/JSTest.Runner/TestRunner/ExecutionManagers/TestSessionManager.ts
+++ b/src/JSTest.Runner/TestRunner/ExecutionManagers/TestSessionManager.ts
@@ -17,7 +17,7 @@ export class TestSessionManager {
     private testSessionIterator: IterableIterator<TestSession>;
     private sessionCompleteCount: number;
     private sessionCount: number;
-    private runInDomain: boolean;
+    protected runInDomain: boolean;
     public onAllSessionsComplete: IEvent<IEventArgs>;
 
     public static instance: TestSessionManager;
@@ -77,11 +77,7 @@ export class TestSessionManager {
     }
 
     public executeJobs() {
-        if (this.runInDomain) {
-            this.runSessionInDomain(this.testSessionIterator.next().value);
-        } else {
-            this.runSession(this.testSessionIterator.next().value);
-        }
+        this.runSession(this.testSessionIterator.next().value);
     }
 
     public updateSessionEventArgs(args: TestSessionEventArgs) {
@@ -95,6 +91,14 @@ export class TestSessionManager {
     }
 
     protected runSession(testSession: TestSession) {
+        if (this.runInDomain) {
+            return this.runSessionInDomain(testSession);
+        } else {
+            return this.runSessionNoDomain(testSession);
+        }
+    }
+
+    protected runSessionNoDomain(testSession: TestSession) {
         try {
             EqtTrace.info(`TestSessionManager: Executing session with no domain`);
             testSession.Job();

--- a/src/JSTest.Runner/TestRunner/TestRunner.ts
+++ b/src/JSTest.Runner/TestRunner/TestRunner.ts
@@ -125,6 +125,6 @@ export class TestRunner {
 
     private initializeSingletons() {
         TestFrameworkFactory.INITIALIZE(this.environment);
-        TestSessionManager.INITIALIZE(this.environment);
+        TestSessionManager.INITIALIZE(this.environment, this.cliArgs.runInDomain);
     }
 }

--- a/src/JSTest/RuntimeManager.cs
+++ b/src/JSTest/RuntimeManager.cs
@@ -40,6 +40,8 @@
             this.settings = settings;
             this.testRunEvents = testRunEvents;
 
+            this.jsProcess.RunInDomain = this.settings.RunInDomain;
+
             if (this.settings.DebugLogs)
             {
                 this.jsProcess.EnableDebugLogs(this.settings.DebugFilePath);
@@ -73,13 +75,13 @@
         private Action<object, string> ProcessErrorReceived => (process, data) =>
         {
             EqtTrace.Error("RuntimeManager: Node {0} StdErr: {1}", this.jsProcess.ProcessId, data);
-            
+
             if (!string.IsNullOrEmpty(data))
             {
                 Console.WriteLine("JSTest: {0} StdErr: {1}", this.jsProcess.ProcessId, data);
             }
         };
-        
+
         public Task CleanProcessAsync()
         {
             try
@@ -150,7 +152,7 @@
             {
                 EqtTrace.Verbose("RuntimeManager: Initializing communication with client process.");
                 var connectionStopwatch = Stopwatch.StartNew();
-                
+
                 // Start the message loop
                 Task.Run(() => { this.MessageLoopAsync(this.jsProcess.CommunicationChannel, cancellationToken); });
                 this.jsProcess.CommunicationChannel.SendMessage(MessageType.TestRunSettings, settings);

--- a/src/JSTest/Settings/JSTestSettings.cs
+++ b/src/JSTest/Settings/JSTestSettings.cs
@@ -16,6 +16,8 @@ namespace JSTest.Settings
 
         #region JS Runner Specific Settings
 
+        public bool RunInDomain { get; set; }
+
         public bool DebugLogs { get; set; }
 
         public string DebugFilePath { get; set; }
@@ -98,6 +100,7 @@ namespace JSTest.Settings
             this.JavaScriptTestFramework = JSTestFramework.Jasmine;
             this.Discovery = false;
             this.RunInParallel = true;
+            this.RunInDomain = true;
             this.DebugLogs = false;
             this.NodePath = string.Empty;
             this.NodeModulesPath = string.Empty;

--- a/test/JSTest.Runner.UnitTests/TestRunner/ArgProcessorTests.ts
+++ b/test/JSTest.Runner.UnitTests/TestRunner/ArgProcessorTests.ts
@@ -1,4 +1,5 @@
 import * as assert from 'assert';
+
 import { ArgProcessor } from '../../../src/JSTest.Runner/ArgProcessor';
 import { CLIArgs } from '../../../src/JSTest.Runner/TestRunner/CLIArgs';
 
@@ -16,7 +17,8 @@ describe('ArgProcessor Suite', () => {
             ip: '192.168.1.1',
             port: '9999',
             traceEnabled: false,
-            traceFilePath: ''
+            traceFilePath: '',
+            runInDomain: false
         });
     });
     
@@ -28,7 +30,8 @@ describe('ArgProcessor Suite', () => {
             ip: '192.168.1.1',
             port: '9999',
             traceEnabled: true,
-            traceFilePath: ''
+            traceFilePath: '',
+            runInDomain: false
         });
     });
 
@@ -40,7 +43,21 @@ describe('ArgProcessor Suite', () => {
             ip: '192.168.1.1',
             port: '9999',
             traceEnabled: true,
-            traceFilePath: 'file'
+            traceFilePath: 'file',
+            runInDomain: false
+        });
+    });
+    
+    it('Will enable running in domain for logs for --runInDomain', () => {
+        mockEnv.argv = [process.env[0], process.env[1], '192.168.1.1', '9999', '--runInDomain'];
+        const args: CLIArgs = ArgProcessor.processCLIArgs(mockEnv);
+        
+        assert.deepEqual(args, {
+            ip: '192.168.1.1',
+            port: '9999',
+            traceEnabled: false,
+            traceFilePath: '',
+            runInDomain: true
         });
     });
 

--- a/test/JSTest.Runner.UnitTests/TestRunner/ExecutionManager/BaseExecutionManagerTests.ts
+++ b/test/JSTest.Runner.UnitTests/TestRunner/ExecutionManager/BaseExecutionManagerTests.ts
@@ -1,8 +1,9 @@
+import * as Assert from 'assert';
+
 import { Environment } from '../../../../src/JSTest.Runner/Environment/Node/Environment';
+import { Event } from '../../../../src/JSTest.Runner/Events/Event';
 import { TestFrameworkFactory } from '../../../../src/JSTest.Runner/TestRunner/TestFrameworks/TestFrameworkFactory';
 import { TestSessionManager } from '../../../../src/JSTest.Runner/TestRunner/ExecutionManagers/TestSessionManager';
-import { Event } from '../../../../src/JSTest.Runner/Events/Event';
-import * as Assert from 'assert';
 import { TestableBaseExecutionManager } from './Testable';
 
 describe('BaseExecutionManager Suite', () => {
@@ -10,7 +11,7 @@ describe('BaseExecutionManager Suite', () => {
     const environment = new Environment();
 
     TestFrameworkFactory.INITIALIZE(environment);
-    TestSessionManager.INITIALIZE(environment);
+    TestSessionManager.INITIALIZE(environment, true);
 
     before(() => {
         executionManager = new TestableBaseExecutionManager(environment);

--- a/test/JSTest.Runner.UnitTests/TestRunner/ExecutionManager/DiscoveryManagerTests.ts
+++ b/test/JSTest.Runner.UnitTests/TestRunner/ExecutionManager/DiscoveryManagerTests.ts
@@ -26,7 +26,7 @@ describe('DiscoveryManager Suite', () => {
     const environment = new Environment();
 
     const testableTestFrameworkFactory = new TestableTestFrameworkFactory(environment);
-    const testableTestSessionManager = new TestableTestSessionManager(environment);
+    const testableTestSessionManager = new TestableTestSessionManager(environment, true);
 
     before(() => {
         mockFactory = Mock.ofInstance(testableTestFrameworkFactory);

--- a/test/JSTest.Runner.UnitTests/TestRunner/ExecutionManager/ExecutionManagerTests.ts
+++ b/test/JSTest.Runner.UnitTests/TestRunner/ExecutionManager/ExecutionManagerTests.ts
@@ -35,7 +35,7 @@ describe('ExecutionManager Suite', () => {
     const environment = new Environment();
 
     const testableTestFrameworkFactory = new TestableTestFrameworkFactory(environment);
-    const testableTestSessionManager = new TestableTestSessionManager(environment);
+    const testableTestSessionManager = new TestableTestSessionManager(environment, true);
 
     before(() => {
         mockFactory = Mock.ofInstance(testableTestFrameworkFactory);

--- a/test/JSTest.Runner.UnitTests/TestRunner/ExecutionManager/TestSessionManagerTests.ts
+++ b/test/JSTest.Runner.UnitTests/TestRunner/ExecutionManager/TestSessionManagerTests.ts
@@ -203,11 +203,8 @@ describe('TestSessionManager Sutie', () => {
             Sources: ['file 1'],
             TestSessionEventArgs: args,
             Job: () => { 
-                setTimeout(() => {
-                    // should throw an error but will be caught by try catch and not domain
-                    // tslint:disable:no-require-imports
-                    require('asdfasdf');
-                }, 100);
+                // tslint:disable:no-require-imports
+                require('asdfasdf');
             },
             ErrorCallback: errorCallback,
             Complete: false

--- a/test/JSTest.Runner.UnitTests/TestRunner/ExecutionManager/TestSessionManagerTests.ts
+++ b/test/JSTest.Runner.UnitTests/TestRunner/ExecutionManager/TestSessionManagerTests.ts
@@ -10,7 +10,7 @@ describe('TestSessionManager Sutie', () => {
     
     beforeEach(() => {
         TestSessionManager.instance = undefined;
-        TestSessionManager.INITIALIZE(new Environment());
+        TestSessionManager.INITIALIZE(new Environment(), true);
         testSessionManager = TestSessionManager.instance;
     });
 
@@ -111,7 +111,7 @@ describe('TestSessionManager Sutie', () => {
 
     it('domain will catch error and call error callback and update event args', (done) => {
         const args = new TestSessionEventArgs(['file 1'], SessionHash(['file 1']));
-        const sessionManager = new TestableTestSessionManager(new Environment());
+        const sessionManager = new TestableTestSessionManager(new Environment(), true);
         let errorCallbackInvoked: boolean = false;
         let domainErrorEventRaised: boolean = false;
 
@@ -137,7 +137,7 @@ describe('TestSessionManager Sutie', () => {
             validate();
         };
 
-        const domain = sessionManager.runSession(<TestSession> {
+        const domain = sessionManager.runTestSession(<TestSession> {
             Sources: ['file 1'],
             TestSessionEventArgs: args,
             Job: () => { 
@@ -158,7 +158,7 @@ describe('TestSessionManager Sutie', () => {
 
     it('runSessionInDomain will handle require errors as well', (done) => {
         const args = new TestSessionEventArgs(['file 1'], SessionHash(['file 1']));
-        const sessionManager = new TestableTestSessionManager(new Environment());
+        const sessionManager = new TestableTestSessionManager(new Environment(), true);
 
         const errorCallback = (err: Error) => { 
             // Error was called and cought in domain;
@@ -168,7 +168,38 @@ describe('TestSessionManager Sutie', () => {
             done();
         };
         
-        sessionManager.runSession(<TestSession> {
+        sessionManager.runTestSession(<TestSession> {
+            Sources: ['file 1'],
+            TestSessionEventArgs: args,
+            Job: () => { 
+                setTimeout(() => {
+                    // should throw an error but will be caught by try catch and not domain
+                    // tslint:disable:no-require-imports
+                    require('asdfasdf');
+                }, 100);
+            },
+            ErrorCallback: errorCallback,
+            Complete: false
+        });
+
+        Assert.strictEqual(args.EndTime, undefined);
+        Assert.strictEqual(args.InProgress, true);
+
+    });
+
+    it('runSessionNoDomain will handle require errors as well', (done) => {
+        const args = new TestSessionEventArgs(['file 1'], SessionHash(['file 1']));
+        const sessionManager = new TestableTestSessionManager(new Environment(), false);
+
+        const errorCallback = (err: Error) => { 
+            // Error was called and cought in domain;
+            Assert.equal(err.message.startsWith('Cannot find module'), true);
+            Assert.notStrictEqual(args.EndTime, undefined);
+            Assert.strictEqual(args.InProgress, false);
+            done();
+        };
+        
+        sessionManager.runTestSession(<TestSession> {
             Sources: ['file 1'],
             TestSessionEventArgs: args,
             Job: () => { 

--- a/test/JSTest.Runner.UnitTests/TestRunner/ExecutionManager/Testable.ts
+++ b/test/JSTest.Runner.UnitTests/TestRunner/ExecutionManager/Testable.ts
@@ -1,13 +1,14 @@
-import { IEnvironment } from '../../../../src/JSTest.Runner/Environment/IEnvironment';
-import { ITestFrameworkEvents, ITestFramework, TestFrameworks } from '../../../../src/JSTest.Runner/ObjectModel/TestFramework';
+import { DiscoveryManager, ExecutionManager } from '../../../../src/JSTest.Runner/TestRunner/ExecutionManagers';
 import { EnvironmentType, IEvent, IEventArgs } from '../../../../src/JSTest.Runner/ObjectModel/Common';
-import { TestFrameworkEventHandlers } from '../../../../src/JSTest.Runner/TestRunner/TestFrameworks/TestFrameworkEventHandlers';
-import { ExecutionManager, DiscoveryManager } from '../../../../src/JSTest.Runner/TestRunner/ExecutionManagers';
-import { MessageSender } from '../../../../src/JSTest.Runner/TestRunner/MessageSender';
-import { JSTestSettings } from '../../../../src/JSTest.Runner/ObjectModel';
+import { ITestFramework, ITestFrameworkEvents, TestFrameworks } from '../../../../src/JSTest.Runner/ObjectModel/TestFramework';
+import { TestSession, TestSessionManager } from '../../../../src/JSTest.Runner/TestRunner/ExecutionManagers/TestSessionManager';
+
 import { BaseExecutionManager } from '../../../../src/JSTest.Runner/TestRunner/ExecutionManagers/BaseExecutionManager';
+import { IEnvironment } from '../../../../src/JSTest.Runner/Environment/IEnvironment';
+import { JSTestSettings } from '../../../../src/JSTest.Runner/ObjectModel';
+import { MessageSender } from '../../../../src/JSTest.Runner/TestRunner/MessageSender';
+import { TestFrameworkEventHandlers } from '../../../../src/JSTest.Runner/TestRunner/TestFrameworks/TestFrameworkEventHandlers';
 import { TestFrameworkFactory } from '../../../../src/JSTest.Runner/TestRunner/TestFrameworks/TestFrameworkFactory';
-import { TestSessionManager, TestSession } from '../../../../src/JSTest.Runner/TestRunner/ExecutionManagers/TestSessionManager';
 
 export class TestableFramework implements ITestFramework {
     public executorUri: string = '';
@@ -116,12 +117,12 @@ export class TestableBaseExecutionManager extends BaseExecutionManager {
 }
 
 export class TestableTestSessionManager extends TestSessionManager {
-    constructor(env: IEnvironment) {
-        super(env);
+    constructor(env: IEnvironment, runInDomain: boolean) {
+        super(env, runInDomain);
     }
-
-    public runSession(testSession: TestSession) {
-        return this.runSessionInDomain(testSession);
+    
+    public runTestSession(testSession: TestSession): any {
+        return super.runSession(testSession);
     }
 }
 


### PR DESCRIPTION
Add a "RunInDomain" option to JSTestSettings.

Some environments, such as [Playwright](https://playwright.dev/), are not compatible with running tests inside a node Domain. Node domains are also deprecated.

This PR turns running inside a domain into an option (default `true` for backwards compatibility).